### PR TITLE
fix: update git clone repo based on current repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pip install pytrim
 
 ### Source Installation
 ```bash
-git clone https://github.com/karyotakisg/PyTrim.git
+git clone git@github.com:TrimTeam/PyTrim.git
 cd PyTrim
 pip install .
 ```


### PR DESCRIPTION
saw this repo from the paper reference and noticed that the git clone is still referencing the original location 